### PR TITLE
Fix for missing underlayer issue in Atom 206 that causes activation fail

### DIFF
--- a/lib/ruler-view.coffee
+++ b/lib/ruler-view.coffee
@@ -20,6 +20,10 @@ class RulerView extends HTMLElement
   insert: ->
     editor_view = atom.views.getView(@model.getCursor().editor)
     underlayer = editor_view.getElementsByClassName('underlayer')[0]
+    if !underlayer
+      underlayer = document.createElement("div")
+      underlayer.className = "underlayer"
+      editor_view.appendChild(underlayer)
     underlayer.appendChild @
 
   subscribe: ->


### PR DESCRIPTION
Not sure it's the best fix, but it works :-)
