### PR TITLE
Makes sure that the ruler shows when typing

### DIFF
--- a/lib/ruler-view.coffee
+++ b/lib/ruler-view.coffee
@@ -42,6 +42,7 @@ class RulerView extends HTMLElement
     view        = @getEditor()
     position    = view.pixelPositionForScreenPosition point
     @style.left = position.left + 'px'
+    @insert()
 
   # Clean up.
   destroy: ->


### PR DESCRIPTION
The optimizations to the line handling in Atom mean that the ruler will not draw reliably, if for example you scroll down a file, search, re-size the window, etc.

By putting the insert here it makes sure the ruler gets redrawn when the cursor moves, which is good enough for me right now. My understanding of the appendChild(), is that it'll move the element as opposed to coping, although it doesn't cover some of the cases.
