### PR TITLE
Config removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,6 @@ A simple Atom [package](https://atom.io/packages/rulerz) to mark each of your cu
 
 [![screencast gif](https://cloud.githubusercontent.com/assets/281467/5994471/d3648c72-aa42-11e4-8916-bdd4705ed55c.gif)](http://www.forgecrafted.com)
 
-## Configuration
-
-Configure rulerz in the package settings (`ctrl-,`) dialog, or manually in your `config.cson`. The following settings are currently supported:
-
-#### enabled (*boolean*) - turn rulerz on or off
-
-Example:
-
-```coffee
-  rulerz:
-    enabled: true
-```
-
 ## Styles
 
 You can change the appearance of the rulers by adding a rule to your stylesheet (File -> Open your Stylesheet). For example:

--- a/README.md
+++ b/README.md
@@ -19,13 +19,26 @@ Example:
     enabled: true
 ```
 
-#### width (*integer*) - the width (in pixels) of each ruler
+## Styles
 
-Example:
+You can change the appearance of the rulers by adding a rule to your stylesheet (File -> Open your Stylesheet). For example:
 
-```coffee
-  rulerz:
-    width: 1
+```less
+atom-text-editor.is-focused::shadow {
+  ruler-view.rulerz {
+    border-left: 1px solid black;
+  }
+}
+```
+
+The default color is taken from the variable `@text-color-subtle`. By continuing to base your ruler color on this value (modified with LESS functions), your ruler will match whatever syntax theme you have active:
+
+```less
+atom-text-editor.is-focused::shadow {
+  ruler-view.rulerz {
+    border-left: 1px dotted fade(mix(@text-color-subtle, limegreen), 5%);
+  }
+}
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simple Atom [package](https://atom.io/packages/rulerz) to mark each of your cu
 
 ## Styles
 
-You can change the appearance of the rulers by adding a rule to your stylesheet (File -> Open your Stylesheet). For example:
+You can change the appearance of the rulers by adding a rule to [your stylesheet](https://atom.io/docs/latest/using-atom-basic-customization#style-tweaks). For example:
 
 ```less
 atom-text-editor.is-focused::shadow {

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -9,10 +9,6 @@ module.exports =
       title: 'Display a Ruler on each Cursor'
       type: 'boolean'
       default: true
-    width:
-      title: 'Width of each Ruler (in pixels)'
-      type: 'integer'
-      default: 1
 
   activate: ->
     @subscriptions = new CompositeDisposable

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,40 +2,10 @@
 RulerManager = require './ruler-manager.coffee'
 
 module.exports =
-  subscriptions: null
-
-  config:
-    enabled:
-      title: 'Display a Ruler on each Cursor'
-      type: 'boolean'
-      default: true
 
   activate: ->
-    @subscriptions = new CompositeDisposable
-    @subscriptions.add atom.config.observe 'rulerz.enabled', (newValue) =>
-      if newValue then @doEnable() else @doDisable()
-
-  deactivate: ->
-    @subscriptions.dispose()
-    @subscriptions = null
-
-  toggle: ->
-    atom.config.set 'rulerz.enabled', !@enabled()
-
-  enabled: ->
-    atom.config.get('rulerz.enabled') is true
-
-  enable: ->
-    atom.config.set 'rulerz.enabled', true
-    @doEnable()
-
-  disable: ->
-    atom.config.set 'rulerz.enabled', false
-    @doDisable()
-
-  doEnable: ->
     @rulerzManager = new RulerManager()
 
-  doDisable: ->
+  deactivate: ->
     @rulerzManager?.destroy()
     @rulerzManager = null

--- a/lib/ruler-view.coffee
+++ b/lib/ruler-view.coffee
@@ -8,7 +8,6 @@ class RulerView extends HTMLElement
 
   createdCallback: ->
     @classList.add 'rulerz'
-    @style['border-left-width'] = atom.config.get('rulerz.width') + 'px'
 
   initialize: (model) ->
     @subscriptions = new CompositeDisposable
@@ -33,9 +32,6 @@ class RulerView extends HTMLElement
     # Watch the cursor for changes.
     @subscriptions.add @model.onDidChange @update.bind(@)
     @subscriptions.add @model.onDidDestroy @destroy.bind(@)
-    # Watch the config for changes.
-    @subscriptions.add atom.config.observe 'rulerz.width', (newValue) =>
-      @style['border-left-width'] = newValue + 'px'
 
   # Change the left alignment of the ruler.
   update: (point) ->


### PR DESCRIPTION
Hello, I hope you don't mind unsolicited pull requests, especially ones that are basically a big deletion?

I started off wanting to change the color of rulerz's ruler lines, which entailed adding a stylesheet rule. I then realised we could potentially set the width there too, but that was blocked by the "width" config overwriting it. So I forked and removed the width config. It seems to me that using the stylesheet is the Atom-y way of doing this kind of thing.

Then I realised the "enable" config option was surplus to requirement since atom has its own enable/disable in the package manager now. So I kinda deleted all the config subscriptions and replaced them with a note in the README.
