### PR TITLE
updated shadowRoot deprecation

### DIFF
--- a/lib/ruler-view.coffee
+++ b/lib/ruler-view.coffee
@@ -19,7 +19,7 @@ class RulerView extends HTMLElement
 
   getEditor: ->
     @editor = atom.views.getView @model.getCursor().editor
-    root    = @editor.shadowRoot ? @editor
+    root    = @editor.syntax ? @editor
     @lines  = root.querySelector '.scroll-view .lines'
     @editor
 

--- a/styles/cursor-ruler.less
+++ b/styles/cursor-ruler.less
@@ -4,7 +4,7 @@
 // for a full listing of what's available.
 @import "ui-variables";
 
-atom-text-editor.is-focused::shadow {
+atom-text-editor.is-focused.editor {
   ruler-view.rulerz {
     position: absolute;
     display: block;


### PR DESCRIPTION
Fixes deprecation: The contents of atom-text-editor elements are no longer encapsulated
within a shadow DOM boundary. Please, stop using shadowRoot and access
the editor contents directly instead.